### PR TITLE
Fix direct memory leak of cr->r

### DIFF
--- a/cgranges.c
+++ b/cgranges.c
@@ -104,6 +104,7 @@ void cr_destroy(cgranges_t *cr)
 		free(cr->ctg[i].name);
 	free(cr->ctg);
 	kh_destroy(str, (strhash_t*)cr->hc);
+	free(cr->r);
 	free(cr);
 }
 


### PR DESCRIPTION
in `cr_destroy`, the contig names and hash table are freed; then the cgranges_t itself, but not its constituent array of intervals, cr->r.